### PR TITLE
Paillier scheme API - evaluation and clearing up

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -117,17 +117,12 @@ type dbPrivateKey struct {
 
 func (this *PrivateKey) GetBSON() (interface{}, error) {
 	m := make(map[string]string)
-	if this.G != nil {
-		m["g"] = fmt.Sprintf("%x", this.G)
-	}
+
 	if this.N != nil {
 		m["n"] = fmt.Sprintf("%x", this.N)
 	}
 	if this.Lambda != nil {
 		m["lambda"] = fmt.Sprintf("%x", this.Lambda)
-	}
-	if this.Mu != nil {
-		m["mu"] = fmt.Sprintf("%x", this.Mu)
 	}
 	return m, nil
 }
@@ -143,20 +138,12 @@ func (this *PrivateKey) SetBSON(raw bson.Raw) error {
 			return err
 		}
 	}
-	if c.G != "" {
-		this.G, err = fromHex(c.G)
-		if err != nil {
-			return err
-		}
-	}
+
 	if c.Lambda != "" {
 		this.Lambda, err = fromHex(c.Lambda)
 		if err != nil {
 			return err
 		}
-	}
-	if c.Mu != "" {
-		this.Mu, err = fromHex(c.Mu)
 	}
 
 	return err

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -118,6 +118,6 @@ func TestPartialDecryptionZKPBSONification(t *testing.T) {
 }
 
 func TestThresholdKeyBSON(t *testing.T) {
-	key := &ThresholdKey{PublicKey{b(9), b(8)}, 7, 6, b(3), []*big.Int{b(2), b(34)}}
+	key := &ThresholdKey{PublicKey{b(9)}, 7, 6, b(3), []*big.Int{b(2), b(34)}, b(8)}
 	AssertBSONIsGood(key, new(ThresholdKey), t)
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -118,6 +118,6 @@ func TestPartialDecryptionZKPBSONification(t *testing.T) {
 }
 
 func TestThresholdKeyBSON(t *testing.T) {
-	key := &ThresholdKey{PublicKey{b(9), b(8), nil}, 7, 6, b(3), []*big.Int{b(2), b(34)}}
+	key := &ThresholdKey{PublicKey{b(9), b(8)}, 7, 6, b(3), []*big.Int{b(2), b(34)}}
 	AssertBSONIsGood(key, new(ThresholdKey), t)
 }

--- a/paillier.go
+++ b/paillier.go
@@ -7,12 +7,11 @@ import (
 )
 
 type PublicKey struct {
-	N, G *big.Int // usually G is set to N+1
+	N *big.Int // usually G is set to N+1
 }
 
 func (this *PublicKey) GetBSON() (interface{}, error) {
 	m := make(map[string]string)
-	m["g"] = fmt.Sprintf("%x", this.G)
 	m["n"] = fmt.Sprintf("%x", this.N)
 	return m, nil
 }
@@ -57,8 +56,7 @@ type PrivateKey struct {
 }
 
 func (this *PrivateKey) String() string {
-	ret := fmt.Sprintf("g     :  %x", this.G)
-	ret += fmt.Sprintf("n     :  %x", this.N)
+	ret := fmt.Sprintf("n     :  %x", this.N)
 	ret += fmt.Sprintf("lambda:  %x", this.Lambda)
 	return ret
 }

--- a/paillier.go
+++ b/paillier.go
@@ -7,7 +7,7 @@ import (
 )
 
 type PublicKey struct {
-	N *big.Int // usually G is set to N+1
+	N *big.Int
 }
 
 func (this *PublicKey) GetBSON() (interface{}, error) {

--- a/paillier.go
+++ b/paillier.go
@@ -8,7 +8,6 @@ import (
 
 type PublicKey struct {
 	N, G *big.Int // usually G is set to N+1
-	n2   *big.Int // the cache value of N^2
 }
 
 func (this *PublicKey) GetBSON() (interface{}, error) {
@@ -19,11 +18,7 @@ func (this *PublicKey) GetBSON() (interface{}, error) {
 }
 
 func (this *PublicKey) GetNSquare() *big.Int {
-	if this.n2 != nil {
-		return this.n2
-	}
-	this.n2 = new(big.Int).Mul(this.N, this.N)
-	return this.n2
+	return new(big.Int).Mul(this.N, this.N)
 }
 
 // Encode a plaintext in a cypher one. The plain text must be smaller that

--- a/paillier.go
+++ b/paillier.go
@@ -55,12 +55,6 @@ type PrivateKey struct {
 	Lambda *big.Int
 }
 
-func (this *PrivateKey) String() string {
-	ret := fmt.Sprintf("n     :  %x", this.N)
-	ret += fmt.Sprintf("lambda:  %x", this.Lambda)
-	return ret
-}
-
 // Decodes ciphertext into a plaintext message.
 //
 // c - cyphertext to decrypt

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -8,10 +8,11 @@ import (
 )
 
 func TestLCM(t *testing.T) {
-	a := big.NewInt(2 * 3 * 3 * 3 * 5 * 5)
-	b := big.NewInt(3 * 3 * 5 * 5 * 57 * 11)
-	exp := big.NewInt(3 * 3 * 5 * 5)
-	if reflect.DeepEqual(exp, LCM(a, b)) {
+	a := big.NewInt(1350)
+	b := big.NewInt(141075)
+	expected := big.NewInt(282150)
+
+	if !reflect.DeepEqual(expected, LCM(a, b)) {
 		t.Fail()
 	}
 }
@@ -35,7 +36,7 @@ func TestComputeMu(t *testing.T) {
 
 	exp := big.NewInt(3)
 	if !reflect.DeepEqual(computeMu(g, lambda, n), exp) {
-		t.Error("lambda is not well computed")
+		t.Error("mu is not well computed")
 	}
 }
 

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -40,6 +40,16 @@ func TestComputeMu(t *testing.T) {
 	}
 }
 
+func TestComputeLambda(t *testing.T) {
+	a := big.NewInt(5)
+	b := big.NewInt(7)
+	expected := big.NewInt(12)
+
+	if !reflect.DeepEqual(expected, computeLamda(a, b)) {
+		t.Error("lambda is not correctly computed")
+	}
+}
+
 func TestEncryptDecryptSmall(t *testing.T) {
 	p := big.NewInt(13)
 	q := big.NewInt(11)

--- a/paillier_test.go
+++ b/paillier_test.go
@@ -7,46 +7,42 @@ import (
 	"testing"
 )
 
-func TestLCM(t *testing.T) {
-	a := big.NewInt(1350)
-	b := big.NewInt(141075)
-	expected := big.NewInt(282150)
-
-	if !reflect.DeepEqual(expected, LCM(a, b)) {
-		t.Fail()
-	}
-}
-
-func TestL(t *testing.T) {
+func TestComputeL(t *testing.T) {
 	u := big.NewInt(21)
 	n := big.NewInt(3)
-	exp := big.NewInt(6)
-	if !reflect.DeepEqual(exp, L(u, n)) {
-		t.Error("L function is not good")
+
+	expected := big.NewInt(6)
+	actual := L(u, n)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected L function result [%v]", actual)
 	}
 }
 
-func TestComputeMu(t *testing.T) {
-	p := big.NewInt(13)
-	q := big.NewInt(11)
-
-	lambda := computeLamda(p, q)
-	g := big.NewInt(5000)
-	n := new(big.Int).Mul(p, q)
-
-	exp := big.NewInt(3)
-	if !reflect.DeepEqual(computeMu(g, lambda, n), exp) {
-		t.Error("mu is not well computed")
-	}
-}
-
-func TestComputeLambda(t *testing.T) {
+func TestComputePhi(t *testing.T) {
 	a := big.NewInt(5)
 	b := big.NewInt(7)
-	expected := big.NewInt(12)
 
-	if !reflect.DeepEqual(expected, computeLamda(a, b)) {
-		t.Error("lambda is not correctly computed")
+	expected := big.NewInt(24)
+	actual := computePhi(a, b)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Unexpected phi value [%v]", actual)
+	}
+}
+
+func TestCreatePrivateKey(t *testing.T) {
+	p := big.NewInt(463)
+	q := big.NewInt(631)
+
+	privateKey := CreatePrivateKey(p, q)
+
+	if !reflect.DeepEqual(privateKey.N, big.NewInt(292153)) {
+		t.Errorf("Unexpected N PublicKey value [%v]", privateKey.N)
+	}
+
+	if !reflect.DeepEqual(privateKey.Lambda, big.NewInt(291060)) {
+		t.Errorf("Unexpected Lambda Public key value [%v]", privateKey.Lambda)
 	}
 }
 
@@ -63,10 +59,9 @@ func TestEncryptDecryptSmall(t *testing.T) {
 		}
 		returnedValue := privateKey.Decrypt(cypher)
 		if !reflect.DeepEqual(inicialValue, returnedValue) {
-			t.Error("wrond decryption ", returnedValue, " is not ", inicialValue)
+			t.Error("wrong decryption ", returnedValue, " is not ", inicialValue)
 		}
 	}
-
 }
 
 func TestAddCypher(t *testing.T) {

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -14,6 +14,7 @@ type ThresholdKey struct {
 	Threshold                      int
 	V                              *big.Int
 	Vi                             []*big.Int
+	G                              *big.Int
 }
 
 // returns the value of (4*delta**2)** -1  mod n

--- a/thresholdkey.go
+++ b/thresholdkey.go
@@ -14,7 +14,7 @@ type ThresholdKey struct {
 	Threshold                      int
 	V                              *big.Int
 	Vi                             []*big.Int
-	G                              *big.Int
+	G                              *big.Int // usually G is set to N+1
 }
 
 // returns the value of (4*delta**2)** -1  mod n


### PR DESCRIPTION
For the needs of https://github.com/keep-network/keep-core/issues/115 I've been evaluating the forked Go implementation of Paillier scheme. The implementation looks solid, I found few flaws I am addressing here. In this PR we look only on a standard, non-threshold scheme.

The code for generating private key is based on approach described in [KL 08], construction 11.32 which is compatible with the one described in [DJN 10], section 3.2 except that instead of generating Lamda private key compontent from LCM of `p` and `q` we use Euler's totient function as suggested in [KL 08]. I cleared up naming as well as removed `G` and `Mu` parameters from Paillier key. For the modification of Paillier scheme we use, where `G = N + 1`, `N` is the only one parameter needed for a public key. Also, `Mu` is needed only for decrypting and can be computed there from `Lambda` and `N` so there is no need to keep it in the private key.

I added documentation to <Key, Enc, Dec> functions with an important note that `p` and `q` supplied to `CreatePrivateKey` must be either of equal length or `gcd(pq, (p-1)(q-1)) = 1` which is assured if both primes are of equal length. This requirement is mentioned both in [KL 08] and [DJN 10].

I had to add `G` to the `ThresholdKey` to make the code compile but I'll evaluate if this parameter is really needed for a threshold version of Paillier. 

I've also removed `PrivateKey`'s `String()` method and cached `N^2` value from `PublicKey`.
It's better to have no code encouraging to turn key into a string and printing it somewhere, especially that string contained private `Lambda` parameter.
For `N^2` caching, I'd like to keep the key structure clean. Computing `N^2` is just a really small piece of encryption/decryption work and if we decide we need to tweak performance, we will need a different approach anyway.

[KL 08]: Jonathan Katz, Yehuda Lindell, (2008)
          Introduction to Modern Cryptography: Principles and Protocols,
          Chapman & Hall/CRC

[DJN 10]: Ivan Damgard, Mads Jurik, Jesper Buus Nielsen, (2010)
          A Generalization of Paillier’s Public-Key System with Applications to Electronic Voting
          Aarhus University, Dept. of Computer Science, BRICS
