### PR TITLE
Pass a public key bit length when creating a threshold key generator

### DIFF
--- a/safe_prime_generator_test.go
+++ b/safe_prime_generator_test.go
@@ -60,7 +60,7 @@ func TestAsyncGenerator(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				AreSafePrimes(p, q, test.bitLen, t)
+				IsSafePrime(p, q, test.bitLen, t)
 			}
 		})
 	}

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -25,13 +25,13 @@ type ThresholdKeyGenerator struct {
 	Threshold                      int
 	random                         io.Reader
 
-	// Both p1 and q1 are primes of length nbits - 1
-	p1 *big.Int
-	q1 *big.Int
+	p *big.Int // p is prime of `PublicKeyBitLength/2` bits and `p = 2*p1 + 1`
+	q *big.Int // q is prime of `PublicKeyBitLength/2` bits and `q = 2*q1 + 1`
 
-	p       *big.Int // p is prime and p=2*p1+1
-	q       *big.Int // q is prime and q=2*q1+1
-	n       *big.Int // n=p*q
+	p1 *big.Int // p1 is prime of `PublicKeyBitLength/2 - 1` bits
+	q1 *big.Int // q1 is prime of `PublicKeyBitLength/2 - 1` bits
+
+	n       *big.Int // n=p*q and is of `PublicKeyBitLength` bits
 	m       *big.Int // m = p1*q1
 	nSquare *big.Int // nSquare = n*n
 	nm      *big.Int // nm = n*m
@@ -59,12 +59,13 @@ func GetThresholdKeyGenerator(
 	random io.Reader,
 ) (*ThresholdKeyGenerator, error) {
 	if publicKeyBitLength%2 == 1 {
-		// For an odd n-bit number, we can't find two n-1-bit numbers which
-		// multiplied gives an n-bit number.
+		// For an odd n-bit number, we can't find two n/2-bit numbers with two
+		// the most significant bits set on which multiplied gives an n-bit
+		// number.
 		return nil, errors.New("Public key bit length must be an even number")
 	}
 	if publicKeyBitLength < 18 {
-		// We need to find two n-1-bit safe primes, P and Q which are not equal.
+		// We need to find two n/2-bit safe primes, P and Q which are not equal.
 		// This is not possible for n<18.
 		return nil, errors.New("Public key bit length must be at least 18 bits")
 	}

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -2,6 +2,7 @@ package paillier
 
 import (
 	"crypto/rand"
+	"errors"
 	"io"
 	"math/big"
 	"time"
@@ -54,13 +55,17 @@ func GetThresholdKeyGenerator(
 	totalNumberOfDecryptionServers int,
 	threshold int,
 	random io.Reader,
-) *ThresholdKeyGenerator {
-	ret := new(ThresholdKeyGenerator)
-	ret.publicKeyBitLength = publicKeyBitLength // TODO: at least 32
-	ret.TotalNumberOfDecryptionServers = totalNumberOfDecryptionServers
-	ret.Threshold = threshold
-	ret.Random = random
-	return ret
+) (*ThresholdKeyGenerator, error) {
+	if publicKeyBitLength < 18 {
+		return nil, errors.New("Public key bit length must be at least 18 bits")
+	}
+
+	generator := new(ThresholdKeyGenerator)
+	generator.publicKeyBitLength = publicKeyBitLength
+	generator.TotalNumberOfDecryptionServers = totalNumberOfDecryptionServers
+	generator.Threshold = threshold
+	generator.Random = random
+	return generator, nil
 }
 
 func (tkg *ThresholdKeyGenerator) generateSafePrimes() (*big.Int, *big.Int, error) {

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -46,10 +46,11 @@ type ThresholdKeyGenerator struct {
 	polynomialCoefficients []*big.Int
 }
 
-// Preferable way to construct the ThresholdKeyGenerator. No verification
-// is done on the input values.  You need to be sure that nbits is big enough
-// and that Threshold > TotalNumberOfDecryptionServers / 2.
-// The plaintext space for the key will be Z_n.
+// GetThresholdKeyGenerator is a preferable way to construct the
+// ThresholdKeyGenerator.
+// Due to the various properties that must be met for the threshold key to be
+// considered valid, the minimum public key `N` bit length is 18 bits.
+// The plaintext space for the key will be `Z_N`.
 func GetThresholdKeyGenerator(
 	publicKeyBitLength int,
 	totalNumberOfDecryptionServers int,

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -49,7 +49,8 @@ type ThresholdKeyGenerator struct {
 // GetThresholdKeyGenerator is a preferable way to construct the
 // ThresholdKeyGenerator.
 // Due to the various properties that must be met for the threshold key to be
-// considered valid, the minimum public key `N` bit length is 18 bits.
+// considered valid, the minimum public key `N` bit length is 18 bits and the
+// public key bit length should be an even number.
 // The plaintext space for the key will be `Z_N`.
 func GetThresholdKeyGenerator(
 	publicKeyBitLength int,
@@ -57,7 +58,14 @@ func GetThresholdKeyGenerator(
 	threshold int,
 	random io.Reader,
 ) (*ThresholdKeyGenerator, error) {
+	if publicKeyBitLength%2 == 1 {
+		// For an odd n-bit number, we can't find two n-1-bit numbers which
+		// multiplied gives an n-bit number.
+		return nil, errors.New("Public key bit length must be an even number")
+	}
 	if publicKeyBitLength < 18 {
+		// We need to find two n-bit safe primes, P and Q which are not equal.
+		// This is not possible for n<18.
 		return nil, errors.New("Public key bit length must be at least 18 bits")
 	}
 

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -23,7 +23,7 @@ type ThresholdKeyGenerator struct {
 	PublicKeyBitLength             int
 	TotalNumberOfDecryptionServers int
 	Threshold                      int
-	Random                         io.Reader
+	random                         io.Reader
 
 	// Both p1 and q1 are primes of length nbits - 1
 	p1 *big.Int
@@ -73,7 +73,7 @@ func GetThresholdKeyGenerator(
 		PublicKeyBitLength:             publicKeyBitLength,
 		TotalNumberOfDecryptionServers: totalNumberOfDecryptionServers,
 		Threshold:                      threshold,
-		Random:                         random,
+		random:                         random,
 	}, nil
 }
 
@@ -82,7 +82,7 @@ func (tkg *ThresholdKeyGenerator) generateSafePrimes() (*big.Int, *big.Int, erro
 	timeout := 120 * time.Second
 	safePrimeBitLength := tkg.PublicKeyBitLength / 2
 
-	return GenerateSafePrime(safePrimeBitLength, concurrencyLevel, timeout, tkg.Random)
+	return GenerateSafePrime(safePrimeBitLength, concurrencyLevel, timeout, tkg.random)
 }
 
 func (tkg *ThresholdKeyGenerator) initPandP1() error {
@@ -133,7 +133,7 @@ func (tkg *ThresholdKeyGenerator) initPsAndQs() error {
 // v generates a cyclic group of squares in Zn^2.
 func (tkg *ThresholdKeyGenerator) computeV() error {
 	var err error
-	tkg.v, err = GetRandomGeneratorOfTheQuadraticResidue(tkg.nSquare, tkg.Random)
+	tkg.v, err = GetRandomGeneratorOfTheQuadraticResidue(tkg.nSquare, tkg.random)
 	return err
 }
 
@@ -186,7 +186,7 @@ func (tkg *ThresholdKeyGenerator) generateHidingPolynomial() error {
 	tkg.polynomialCoefficients[0] = tkg.d
 	var err error
 	for i := 1; i < tkg.Threshold; i++ {
-		tkg.polynomialCoefficients[i], err = rand.Int(tkg.Random, tkg.nm)
+		tkg.polynomialCoefficients[i], err = rand.Int(tkg.random, tkg.nm)
 		if err != nil {
 			return err
 		}

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -20,7 +20,7 @@ import (
 //               with Applications to Electronic Voting
 //               Aarhus University, Dept. of Computer Science, BRICS
 type ThresholdKeyGenerator struct {
-	publicKeyBitLength             int
+	PublicKeyBitLength             int
 	TotalNumberOfDecryptionServers int
 	Threshold                      int
 	Random                         io.Reader
@@ -70,7 +70,7 @@ func GetThresholdKeyGenerator(
 	}
 
 	return &ThresholdKeyGenerator{
-		publicKeyBitLength:             publicKeyBitLength,
+		PublicKeyBitLength:             publicKeyBitLength,
 		TotalNumberOfDecryptionServers: totalNumberOfDecryptionServers,
 		Threshold:                      threshold,
 		Random:                         random,
@@ -80,7 +80,7 @@ func GetThresholdKeyGenerator(
 func (tkg *ThresholdKeyGenerator) generateSafePrimes() (*big.Int, *big.Int, error) {
 	concurrencyLevel := 4
 	timeout := 120 * time.Second
-	safePrimeBitLength := tkg.publicKeyBitLength / 2
+	safePrimeBitLength := tkg.PublicKeyBitLength / 2
 
 	return GenerateSafePrime(safePrimeBitLength, concurrencyLevel, timeout, tkg.Random)
 }

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -64,7 +64,7 @@ func GetThresholdKeyGenerator(
 		return nil, errors.New("Public key bit length must be an even number")
 	}
 	if publicKeyBitLength < 18 {
-		// We need to find two n-bit safe primes, P and Q which are not equal.
+		// We need to find two n-1-bit safe primes, P and Q which are not equal.
 		// This is not possible for n<18.
 		return nil, errors.New("Public key bit length must be at least 18 bits")
 	}

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -19,7 +19,7 @@ import (
 //               with Applications to Electronic Voting
 //               Aarhus University, Dept. of Computer Science, BRICS
 type ThresholdKeyGenerator struct {
-	nbits                          int
+	publicKeyBitLength             int
 	TotalNumberOfDecryptionServers int
 	Threshold                      int
 	Random                         io.Reader
@@ -49,11 +49,16 @@ type ThresholdKeyGenerator struct {
 // is done on the input values.  You need to be sure that nbits is big enough
 // and that Threshold > TotalNumberOfDecryptionServers / 2.
 // The plaintext space for the key will be Z_n.
-func GetThresholdKeyGenerator(nbits, TotalNumberOfDecryptionServers, Threshold int, random io.Reader) *ThresholdKeyGenerator {
+func GetThresholdKeyGenerator(
+	publicKeyBitLength int,
+	totalNumberOfDecryptionServers int,
+	threshold int,
+	random io.Reader,
+) *ThresholdKeyGenerator {
 	ret := new(ThresholdKeyGenerator)
-	ret.nbits = nbits
-	ret.TotalNumberOfDecryptionServers = TotalNumberOfDecryptionServers
-	ret.Threshold = Threshold
+	ret.publicKeyBitLength = publicKeyBitLength // TODO: at least 32
+	ret.TotalNumberOfDecryptionServers = totalNumberOfDecryptionServers
+	ret.Threshold = threshold
 	ret.Random = random
 	return ret
 }
@@ -61,7 +66,9 @@ func GetThresholdKeyGenerator(nbits, TotalNumberOfDecryptionServers, Threshold i
 func (tkg *ThresholdKeyGenerator) generateSafePrimes() (*big.Int, *big.Int, error) {
 	concurrencyLevel := 4
 	timeout := 120 * time.Second
-	return GenerateSafePrime(tkg.nbits, concurrencyLevel, timeout, tkg.Random)
+	safePrimeBitLength := tkg.publicKeyBitLength / 2
+
+	return GenerateSafePrime(safePrimeBitLength, concurrencyLevel, timeout, tkg.Random)
 }
 
 func (tkg *ThresholdKeyGenerator) initPandP1() error {

--- a/thresholdkey_generator.go
+++ b/thresholdkey_generator.go
@@ -69,12 +69,12 @@ func GetThresholdKeyGenerator(
 		return nil, errors.New("Public key bit length must be at least 18 bits")
 	}
 
-	generator := new(ThresholdKeyGenerator)
-	generator.publicKeyBitLength = publicKeyBitLength
-	generator.TotalNumberOfDecryptionServers = totalNumberOfDecryptionServers
-	generator.Threshold = threshold
-	generator.Random = random
-	return generator, nil
+	return &ThresholdKeyGenerator{
+		publicKeyBitLength:             publicKeyBitLength,
+		TotalNumberOfDecryptionServers: totalNumberOfDecryptionServers,
+		Threshold:                      threshold,
+		Random:                         random,
+	}, nil
 }
 
 func (tkg *ThresholdKeyGenerator) generateSafePrimes() (*big.Int, *big.Int, error) {

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -12,9 +12,8 @@ var MockGenerateSafePrimes = func() (*big.Int, *big.Int, error) {
 }
 
 func TestGenerateSafePrimesOfThresholdKeyGenerator(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Random = rand.Reader
+	tkh := GetThresholdKeyGenerator(32, 4, 3, rand.Reader)
+
 	p, q, err := tkh.generateSafePrimes()
 	if err != nil {
 		t.Error(err)
@@ -23,27 +22,21 @@ func TestGenerateSafePrimesOfThresholdKeyGenerator(t *testing.T) {
 }
 
 func TestInitPandP1(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Random = rand.Reader
+	tkh := GetThresholdKeyGenerator(32, 4, 3, rand.Reader)
 
 	tkh.initPandP1()
 	AreSafePrimes(tkh.p, tkh.p1, 16, t)
 }
 
 func TestInitQandQ1(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Random = rand.Reader
+	tkh := GetThresholdKeyGenerator(32, 4, 3, rand.Reader)
 
 	tkh.initQandQ1()
 	AreSafePrimes(tkh.q, tkh.q1, 16, t)
 }
 
 func TestInitPsAndQs(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Random = rand.Reader
+	tkh := GetThresholdKeyGenerator(32, 4, 3, rand.Reader)
 
 	tkh.initPsAndQs()
 
@@ -102,9 +95,7 @@ func TestInitD(t *testing.T) {
 }
 
 func TestInitNumerialValues(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Random = rand.Reader
+	tkh := GetThresholdKeyGenerator(32, 4, 3, rand.Reader)
 
 	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)
@@ -112,10 +103,7 @@ func TestInitNumerialValues(t *testing.T) {
 }
 
 func TestGenerateHidingPolynomial(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Threshold = 10
-	tkh.Random = rand.Reader
+	tkh := GetThresholdKeyGenerator(32, 15, 10, rand.Reader)
 	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)
 	}
@@ -137,10 +125,7 @@ func TestGenerateHidingPolynomial(t *testing.T) {
 }
 
 func TestComputeShare(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Threshold = 3
-	tkh.TotalNumberOfDecryptionServers = 5
+	tkh := GetThresholdKeyGenerator(32, 5, 3, rand.Reader)
 	tkh.nm = b(103)
 	tkh.polynomialCoefficients = []*big.Int{b(29), b(88), b(51)}
 	share := tkh.computeShare(2)
@@ -150,10 +135,7 @@ func TestComputeShare(t *testing.T) {
 }
 
 func TestCreateShares(t *testing.T) {
-	tkh := new(ThresholdKeyGenerator)
-	tkh.publicKeyBitLength = 32
-	tkh.Threshold = 10
-	tkh.TotalNumberOfDecryptionServers = 100
+	tkh := GetThresholdKeyGenerator(32, 100, 10, rand.Reader)
 	tkh.Random = rand.Reader
 	if err := tkh.initNumerialValues(); err != nil {
 		t.Error(err)

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -20,11 +20,17 @@ func TestCreateThresholdKeyGenerator(t *testing.T) {
 		"generator successfully created for 20 bit key length": {
 			keyLength: 20,
 		},
-
+		"generator can't be created for 19 bit key length": {
+			keyLength:     19,
+			expectedError: errors.New("Public key bit length must be an even number"),
+		},
 		"generator successfully created for 18 bit key length": {
 			keyLength: 18,
 		},
-
+		"generator can't be created for 17 bit key length": {
+			keyLength:     17,
+			expectedError: errors.New("Public key bit length must be an even number"),
+		},
 		"generator can't be created for 16 bit key length": {
 			keyLength:     16,
 			expectedError: errors.New("Public key bit length must be at least 18 bits"),
@@ -60,7 +66,7 @@ func TestGenerateSafePrimesOfThresholdKeyGenerator(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	AreSafePrimes(p, q, 16, t)
+	IsSafePrime(p, q, 16, t)
 }
 
 func TestInitPandP1(t *testing.T) {
@@ -70,7 +76,7 @@ func TestInitPandP1(t *testing.T) {
 	}
 
 	tkh.initPandP1()
-	AreSafePrimes(tkh.p, tkh.p1, 16, t)
+	IsSafePrime(tkh.p, tkh.p1, 16, t)
 }
 
 func TestInitQandQ1(t *testing.T) {
@@ -80,7 +86,7 @@ func TestInitQandQ1(t *testing.T) {
 	}
 
 	tkh.initQandQ1()
-	AreSafePrimes(tkh.q, tkh.q1, 16, t)
+	IsSafePrime(tkh.q, tkh.q1, 16, t)
 }
 
 func TestInitPsAndQs(t *testing.T) {
@@ -91,8 +97,8 @@ func TestInitPsAndQs(t *testing.T) {
 
 	tkh.initPsAndQs()
 
-	AreSafePrimes(tkh.p, tkh.p1, 16, t)
-	AreSafePrimes(tkh.q, tkh.q1, 16, t)
+	IsSafePrime(tkh.p, tkh.p1, 16, t)
+	IsSafePrime(tkh.q, tkh.q1, 16, t)
 }
 
 func TestArePsAndQsGood(t *testing.T) {

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -13,42 +13,42 @@ var MockGenerateSafePrimes = func() (*big.Int, *big.Int, error) {
 
 func TestGenerateSafePrimesOfThresholdKeyGenerator(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Random = rand.Reader
 	p, q, err := tkh.generateSafePrimes()
 	if err != nil {
 		t.Error(err)
 	}
-	AreSafePrimes(p, q, 10, t)
+	AreSafePrimes(p, q, 16, t)
 }
 
 func TestInitPandP1(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Random = rand.Reader
 
 	tkh.initPandP1()
-	AreSafePrimes(tkh.p, tkh.p1, 10, t)
+	AreSafePrimes(tkh.p, tkh.p1, 16, t)
 }
 
 func TestInitQandQ1(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Random = rand.Reader
 
 	tkh.initQandQ1()
-	AreSafePrimes(tkh.q, tkh.q1, 10, t)
+	AreSafePrimes(tkh.q, tkh.q1, 16, t)
 }
 
 func TestInitPsAndQs(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Random = rand.Reader
 
 	tkh.initPsAndQs()
 
-	AreSafePrimes(tkh.p, tkh.p1, 10, t)
-	AreSafePrimes(tkh.q, tkh.q1, 10, t)
+	AreSafePrimes(tkh.p, tkh.p1, 16, t)
+	AreSafePrimes(tkh.q, tkh.q1, 16, t)
 }
 
 func TestArePsAndQsGood(t *testing.T) {
@@ -103,7 +103,7 @@ func TestInitD(t *testing.T) {
 
 func TestInitNumerialValues(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Random = rand.Reader
 
 	if err := tkh.initNumerialValues(); err != nil {
@@ -113,7 +113,7 @@ func TestInitNumerialValues(t *testing.T) {
 
 func TestGenerateHidingPolynomial(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Threshold = 10
 	tkh.Random = rand.Reader
 	if err := tkh.initNumerialValues(); err != nil {
@@ -138,7 +138,7 @@ func TestGenerateHidingPolynomial(t *testing.T) {
 
 func TestComputeShare(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Threshold = 3
 	tkh.TotalNumberOfDecryptionServers = 5
 	tkh.nm = b(103)
@@ -151,7 +151,7 @@ func TestComputeShare(t *testing.T) {
 
 func TestCreateShares(t *testing.T) {
 	tkh := new(ThresholdKeyGenerator)
-	tkh.nbits = 10
+	tkh.publicKeyBitLength = 32
 	tkh.Threshold = 10
 	tkh.TotalNumberOfDecryptionServers = 100
 	tkh.Random = rand.Reader

--- a/thresholdkey_generator_test.go
+++ b/thresholdkey_generator_test.go
@@ -14,35 +14,35 @@ var MockGenerateSafePrimes = func() (*big.Int, *big.Int, error) {
 
 func TestCreateThresholdKeyGenerator(t *testing.T) {
 	var tests = map[string]struct {
-		keyLength                      int
+		publicKeyBitLength             int
 		totalNumberOfDecryptionServers int
 		threshold                      int
 		expectedError                  error
 	}{
 		"generator successfully created for 20 bit key length": {
-			keyLength:                      20,
+			publicKeyBitLength:             20,
 			totalNumberOfDecryptionServers: 6,
 			threshold:                      5,
 		},
 		"generator can't be created for 19 bit key length": {
-			keyLength:                      19,
+			publicKeyBitLength:             19,
 			totalNumberOfDecryptionServers: 4,
 			threshold:                      3,
 			expectedError:                  errors.New("Public key bit length must be an even number"),
 		},
 		"generator successfully created for 18 bit key length": {
-			keyLength:                      18,
+			publicKeyBitLength:             18,
 			totalNumberOfDecryptionServers: 4,
 			threshold:                      3,
 		},
 		"generator can't be created for 17 bit key length": {
-			keyLength:                      17,
+			publicKeyBitLength:             17,
 			totalNumberOfDecryptionServers: 4,
 			threshold:                      3,
 			expectedError:                  errors.New("Public key bit length must be an even number"),
 		},
 		"generator can't be created for 16 bit key length": {
-			keyLength:                      16,
+			publicKeyBitLength:             16,
 			totalNumberOfDecryptionServers: 4,
 			threshold:                      3,
 			expectedError:                  errors.New("Public key bit length must be at least 18 bits"),
@@ -52,7 +52,7 @@ func TestCreateThresholdKeyGenerator(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 			gen, err := GetThresholdKeyGenerator(
-				test.keyLength,
+				test.publicKeyBitLength,
 				test.totalNumberOfDecryptionServers,
 				test.threshold,
 				rand.Reader,
@@ -73,10 +73,10 @@ func TestCreateThresholdKeyGenerator(t *testing.T) {
 					)
 				}
 
-				if test.keyLength != gen.PublicKeyBitLength {
+				if test.publicKeyBitLength != gen.PublicKeyBitLength {
 					t.Fatalf(
 						"Unexpected public key length\nExpected: %v\nActual: %v",
-						test.keyLength,
+						test.publicKeyBitLength,
 						gen.PublicKeyBitLength,
 					)
 				}
@@ -103,30 +103,22 @@ func TestCreateThresholdKeyGenerator(t *testing.T) {
 
 func TestGenerateNumbersOfCorrectBitLength(t *testing.T) {
 	var tests = map[string]struct {
-		keyLength             int
-		expectedPrimeLength   int
-		expectedModulusLength int
+		publicKeyLength     int
+		expectedPrimeLength int
 	}{
-		"key bit length = 32, prime bit length = 16, modulus bit length = 32": {
-			keyLength:             32,
-			expectedPrimeLength:   16,
-			expectedModulusLength: 32,
+		"public key bit length = 32, prime bit length = 16": {
+			publicKeyLength:     32,
+			expectedPrimeLength: 16,
 		},
-		"key bit length = 64, prime bit length = 32, modulus bit length = 64": {
-			keyLength:             64,
-			expectedPrimeLength:   32,
-			expectedModulusLength: 64,
-		},
-		"key bit length = 128, prime bit length = 64, modulus bit length = 128": {
-			keyLength:             128,
-			expectedPrimeLength:   64,
-			expectedModulusLength: 128,
+		"public key bit length = 64, prime bit length = 32": {
+			publicKeyLength:     64,
+			expectedPrimeLength: 32,
 		},
 	}
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			gen, err := GetThresholdKeyGenerator(test.keyLength, 10, 6, rand.Reader)
+			gen, err := GetThresholdKeyGenerator(test.publicKeyLength, 10, 6, rand.Reader)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -139,7 +131,7 @@ func TestGenerateNumbersOfCorrectBitLength(t *testing.T) {
 			if gen.p.BitLen() != test.expectedPrimeLength {
 				t.Fatalf(
 					"Unexpected prime bit length\nExpected %v\n Actual %v",
-					test.expectedModulusLength,
+					test.expectedPrimeLength,
 					gen.p.BitLen(),
 				)
 			}
@@ -147,15 +139,15 @@ func TestGenerateNumbersOfCorrectBitLength(t *testing.T) {
 			if gen.q.BitLen() != test.expectedPrimeLength {
 				t.Fatalf(
 					"Unexpected prime bit length\nExpected %v\n Actual %v",
-					test.expectedModulusLength,
+					test.expectedPrimeLength,
 					gen.q.BitLen(),
 				)
 			}
 
-			if gen.n.BitLen() != test.expectedModulusLength {
+			if gen.n.BitLen() != test.publicKeyLength {
 				t.Fatalf(
 					"Unexpected modulus bit length\nExpected %v\n Actual %v",
-					test.expectedModulusLength,
+					test.publicKeyLength,
 					gen.n.BitLen(),
 				)
 			}

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -184,7 +184,7 @@ func TestupdateCprime(t *testing.T) {
 }
 
 func TestEncryptingDecryptingSimple(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(10, 2, 1, rand.Reader)
+	tkh := GetThresholdKeyGenerator(32, 2, 1, rand.Reader)
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -205,7 +205,7 @@ func TestEncryptingDecryptingSimple(t *testing.T) {
 }
 
 func TestEncryptingDecrypting(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(10, 2, 2, rand.Reader)
+	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -227,7 +227,7 @@ func TestEncryptingDecrypting(t *testing.T) {
 }
 
 func TestHomomorphicThresholdEncryption(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(10, 2, 2, rand.Reader)
+	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
 	tpks, _ := tkh.Generate()
 
 	plainText1 := b(13)
@@ -278,7 +278,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestCombinePartialDecryptionsZKP(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(10, 2, 2, rand.Reader)
+	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -311,7 +311,7 @@ func TestCombinePartialDecryptionsZKP(t *testing.T) {
 }
 
 func TestCombinePartialDecryptionsWith100Shares(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(10, 100, 50, rand.Reader)
+	tkh := GetThresholdKeyGenerator(32, 100, 50, rand.Reader)
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -338,7 +338,7 @@ func TestCombinePartialDecryptionsWith100Shares(t *testing.T) {
 }
 
 func TestVerifyDecryption(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(10, 2, 2, rand.Reader)
+	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
 	tpks, err := tkh.Generate()
 
 	pk := &tpks[0].ThresholdPublicKey

--- a/thresholdkey_test.go
+++ b/thresholdkey_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func getThresholdPrivateKey() *ThresholdPrivateKey {
-	tkh := GetThresholdKeyGenerator(32, 10, 6, rand.Reader)
+	tkh, err := GetThresholdKeyGenerator(32, 10, 6, rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+
 	tpks, err := tkh.Generate()
 	if err != nil {
 		panic(err)
@@ -184,7 +188,11 @@ func TestupdateCprime(t *testing.T) {
 }
 
 func TestEncryptingDecryptingSimple(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(32, 2, 1, rand.Reader)
+	tkh, err := GetThresholdKeyGenerator(32, 2, 1, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -205,7 +213,11 @@ func TestEncryptingDecryptingSimple(t *testing.T) {
 }
 
 func TestEncryptingDecrypting(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	tkh, err := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -227,7 +239,11 @@ func TestEncryptingDecrypting(t *testing.T) {
 }
 
 func TestHomomorphicThresholdEncryption(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	tkh, err := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tpks, _ := tkh.Generate()
 
 	plainText1 := b(13)
@@ -278,7 +294,11 @@ func TestValidate(t *testing.T) {
 }
 
 func TestCombinePartialDecryptionsZKP(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	tkh, err := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -311,7 +331,11 @@ func TestCombinePartialDecryptionsZKP(t *testing.T) {
 }
 
 func TestCombinePartialDecryptionsWith100Shares(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(32, 100, 50, rand.Reader)
+	tkh, err := GetThresholdKeyGenerator(32, 100, 50, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tpks, err := tkh.Generate()
 	if err != nil {
 		t.Error(err)
@@ -338,7 +362,11 @@ func TestCombinePartialDecryptionsWith100Shares(t *testing.T) {
 }
 
 func TestVerifyDecryption(t *testing.T) {
-	tkh := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	tkh, err := GetThresholdKeyGenerator(32, 2, 2, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	tpks, err := tkh.Generate()
 
 	pk := &tpks[0].ThresholdPublicKey

--- a/utils_test.go
+++ b/utils_test.go
@@ -59,7 +59,9 @@ func TestFactorial(t *testing.T) {
 	}
 }
 
-func AreSafePrimes(p, q *big.Int, expectedLength int, t *testing.T) {
+// IsSafePrime checks whether `p` is a safe prime. A safe prime is a prime
+// number of the form `2q + 1`, where `q` is also a prime.
+func IsSafePrime(p, q *big.Int, expectedLength int, t *testing.T) {
 	if l := p.BitLen(); l != expectedLength {
 		t.Error("p does not have the good length. ", l)
 	}


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/115

So far, `GetThresholdKeyGenerator` accepted bit length of safe primes `p` and `q` which multiplied together create a public key `n = pq`. For `l`-bit prime `p` and `q`, public key `n` was a `2l`-bit number.

This ia a bit clumsy. I'd rather expect to specify a bit length of the public key, especially that `n` (public key) defines a plaintext space. Also, I think `p` and `q` safe primes are rather implementation details.

In this PR, `GenThresholdKeyGenerator` accepts bit length of a public key. Two validation rules have been added:
- bit length must be an even number
      For an odd `l`-bit number, we can't find two `l/2`-bit numbers with two the most significant bits set on which multiplied gives an `l`-bit number,
- bit length must be minimum `18`
      we need to find two `l/2`-bit safe primes, `p` and `q` which are not equal. This is not possible for `l<18`.

I removed the comment about required threshold as I am not sure it's correct (active adversary attack against SSS). We'll investigate it separately and add the required validation.

I have also renamed `AreSafePrimes` to `IsSafePrime` - according to the safe prime definition, only the first function argument can be considered a safe prime.
