### PR TITLE
Get random in multiplicative group changed to iterative

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -23,17 +23,16 @@ func Factorial(n int) *big.Int {
 // Generate a random element in the group of all the elements in Z/nZ that
 // has a multiplicative inverse.
 func GetRandomNumberInMultiplicativeGroup(n *big.Int, random io.Reader) (*big.Int, error) {
-	r, err := rand.Int(random, n)
-	if err != nil {
-		return nil, err
-	}
-	zero := big.NewInt(0)
-	one := big.NewInt(1)
-	if zero.Cmp(r) == 0 || one.Cmp(new(big.Int).GCD(nil, nil, n, r)) != 0 {
-		return GetRandomNumberInMultiplicativeGroup(n, random)
-	}
-	return r, nil
+	for {
+		r, err := rand.Int(random, n)
+		if err != nil {
+			return nil, err
+		}
 
+		if ZERO.Cmp(r) != 0 && ONE.Cmp(new(big.Int).GCD(nil, nil, n, r)) == 0 {
+			return r, nil
+		}
+	}
 }
 
 //  Return a random generator of RQn with high probability.  THIS METHOD

--- a/utils.go
+++ b/utils.go
@@ -20,8 +20,14 @@ func Factorial(n int) *big.Int {
 	return ret
 }
 
-// Generate a random element in the group of all the elements in Z/nZ that
-// has a multiplicative inverse.
+// Draws a non-zero, pseudorandom number from a group of integers modulo n.
+//
+// In modular arithmetic, the integers coprime to n from the set
+// {0, 1, ..., n-1} form a group under multiplication modulo n called
+// the multiplicative group if integers modulo n.
+//
+// Two numbers a and b are coprime (or relatively prime) if the only
+// positive integer that divides both of them is 1.
 func GetRandomNumberInMultiplicativeGroup(n *big.Int, random io.Reader) (*big.Int, error) {
 	for {
 		r, err := rand.Int(random, n)


### PR DESCRIPTION
GetRandomNumberInMultiplicativeGroup implementation was changed from recursive to iterative loop.

The iterative approach is always safer than recursion. Although at this point, parameter `n` is always a product of two primes and number of recursive calls is low, there is no guarantee, that `n` will have this property in future. Some protocols for a dealerless key generation make a relaxation on the safe prime requirement, hence, we may have a problem with a recursive calls in future. Even though Go supports tail recursion, there is absolutely no guarantee compiler will optimise the code this way.